### PR TITLE
Add a Dev Container R-based projects

### DIFF
--- a/.devcontainer/.Rprofile
+++ b/.devcontainer/.Rprofile
@@ -20,8 +20,7 @@ if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
   }
 }
 
-# Set CRAN Mirror
+# Set CRAN Mirror and Cairo graph device
 options(repos = c(CRAN = Sys.getenv("CRAN_MIRROR")))
 options(repos = c(CRAN = "https://cran.rstudio.com/"))
-# Ensure R is using Cairo (in place of X11) as graphical editor device.
-options(bitmapType = "cairo")
+options(bitmapType = "cairo") # Ensure R is using Cairo (in place of X11) as graphical editor device.

--- a/.devcontainer/.Rprofile
+++ b/.devcontainer/.Rprofile
@@ -1,0 +1,27 @@
+# Make Vs-Code a good editor for R
+# Source: https://renkun.me/2020/04/14/writing-r-in-vscode-working-with-multiple-r-sessions/
+Sys.setenv(TERM_PROGRAM = "vscode")
+source(file.path(
+  Sys.getenv(
+    if (.Platform$OS.type == "windows") "USERPROFILE" else "HOME"
+  ),
+  ".vscode-R", "init.R"
+))
+
+# Plot could be displayed in a VS Code editor tab.
+# Source: https://github.com/REditorSupport/vscode-R/wiki/Plot-viewer#svg-in-httpgd-webpage
+if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
+  if ("httpgd" %in% .packages(all.available = TRUE)) {
+    options(vsc.plot = FALSE)
+    options(device = function(...) {
+      httpgd::hgd(silent = TRUE)
+      .vsc.browser(httpgd::hgd_url(history = FALSE), viewer = "Beside")
+    })
+  }
+}
+
+# Set CRAN Mirror
+options(repos = c(CRAN = Sys.getenv("CRAN_MIRROR")))
+options(repos = c(CRAN = "https://cran.rstudio.com/"))
+options(repos = c(CRAN = "https://cran.rstudio.com/"))
+#

--- a/.devcontainer/.Rprofile
+++ b/.devcontainer/.Rprofile
@@ -23,5 +23,5 @@ if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") {
 # Set CRAN Mirror
 options(repos = c(CRAN = Sys.getenv("CRAN_MIRROR")))
 options(repos = c(CRAN = "https://cran.rstudio.com/"))
-options(repos = c(CRAN = "https://cran.rstudio.com/"))
-#
+# Ensure R is using Cairo (in place of X11) as graphical editor device.
+options(bitmapType = "cairo")

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,8 @@ FROM ubuntu:24.04
 
 # Step 2 - Set arguments and environment variables
 # Define arguments
-ARG VENV_NAME=SHINY_STOCK_ANALYZER
+ARG PROJECT_NAME="R Shiny Dev"
+ARG VENV_NAME=R_DEV_ENV
 ARG R_VERSION_MAJOR=4
 ARG R_VERSION_MINOR=4
 ARG R_VERSION_PATCH=2
@@ -21,6 +22,7 @@ ARG CRAN_MIRROR=https://cran.rstudio.com/
 ARG QUARTO_VER="1.6.40"
 
 # Define environment variables
+ENV PROJECT_NAME=$PROJECT_NAME
 ENV VENV_NAME=$VENV_NAME
 ENV R_VERSION_MAJOR=$R_VERSION_MAJOR
 ENV R_VERSION_MINOR=$R_VERSION_MINOR
@@ -77,6 +79,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-venv \
     python3-pip \
     lsof \
+    # Necessary for tidyverse
+    freetype2-doc \
+    libharfbuzz-dev \ 
+    libfribidi-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Step 4 - Install R
@@ -115,3 +121,13 @@ RUN python3 -m venv /opt/$VENV_NAME  \
 RUN /opt/$VENV_NAME/bin/pip install --requirement ./settings/requirements.txt
 # NOTE: Instead of using pip3 install, which tries to install packages system-wide (not allowed in Ubuntu 24.04), \
 # We directly call pip from the virtual environment (/opt/$VENV_NAME/bin/pip), ensuring packages are installed inside the environment.
+
+# Step 10 - Start radian automatically
+RUN echo "radian" >> /root/.bashrc
+# Step 10 - Create a radian_profile to automatically source .Rprofile when radian is launched in a Dev Container and Python environment.
+# Set the RADIAN_PROFILE environment variable
+# ENV RADIAN_PROFILE="/root/.config/radian/radian_profile"
+# # Ensure the directory exists
+# RUN mkdir -p /root/.config/radian
+# # Create the radian_profile and source .Rprofile
+# RUN echo "source('/root/.Rprofile')" > /root/.config/radian/radian_profile

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -71,8 +71,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     make \
     tmux \
     python3-launchpadlib \
-    python3.12-dev \
-    python3.12-venv \
+    python3-dev \
+    python3-venv \
     python3-pip \
     lsof \
     && rm -rf /var/lib/apt/lists/*
@@ -100,12 +100,16 @@ RUN Rscript ./settings/install_packages.R
 
 # Step 6 - Install Quarto
 RUN bash ./settings/install_quarto.sh $QUARTO_VER
+
+# Step 7 - Copy Rprofile in root
 COPY .Rprofile /root/
 
-# Step 7 - Set Python Environmentt
+# Step 8 - Set Python Environmentt
 RUN python3 -m venv /opt/$VENV_NAME  \
     && export PATH=/opt/$VENV_NAME/bin:$PATH \
     && echo "source /opt/$VENV_NAME/bin/activate" >> ~/.bashrc
 
-# Step 8 - Install radian (to run R on the command line)
-RUN pip3 install -r ./settings/requirements.txt
+# Step 9 - Install radian (to run R on the command line)
+RUN /opt/$VENV_NAME/bin/pip install --requirement ./settings/requirements.txt
+# NOTE: Instead of using pip3 install, which tries to install packages system-wide (not allowed in Ubuntu 24.04), \
+# We directly call pip from the virtual environment (/opt/$VENV_NAME/bin/pip), ensuring packages are installed inside the environment.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -70,10 +70,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libmagick++-dev \
     make \
     tmux \
-    # python3-launchpadlib \
-    # python3.10-dev \
-    # python3.10-venv \
-    # python3-pip \
+    python3-launchpadlib \
+    python3.12-dev \
+    python3.12-venv \
+    python3-pip \
     lsof \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,111 @@
+# This Dockerfile includes the following five steps:
+
+#     - Import Ubuntu version 24.04 image as the baseline image
+#     - Set arguments and environment variables. That includes the R version settings, the CRAN mirror, etc.
+#     - Install R dependencies and command lines tools- Debian libraries (git, C and Fortran compilers, vim, curl, etc.)
+#     - Install R and set it, and Quarto
+#     - Set Python virtual environment and install radian
+
+# Setting an R environment from scratch 
+# Step 1 - Import base image
+FROM ubuntu:24.04
+
+# Step 2 - Set arguments and environment variables
+# Define arguments
+ARG VENV_NAME=SHINY_STOCK_ANALYZER
+ARG R_VERSION_MAJOR=4
+ARG R_VERSION_MINOR=4
+ARG R_VERSION_PATCH=2
+ARG DEBIAN_FRONTEND=noninteractive
+ARG CRAN_MIRROR=https://cran.rstudio.com/
+ARG QUARTO_VER="1.6.40"
+
+# Define environment variables
+ENV VENV_NAME=$VENV_NAME
+ENV R_VERSION_MAJOR=$R_VERSION_MAJOR
+ENV R_VERSION_MINOR=$R_VERSION_MINOR
+ENV R_VERSION_PATCH=$R_VERSION_PATCH
+ENV QUARTO_VER=$QUARTO_VER
+ENV CONFIGURE_OPTIONS="--with-cairo --with-jpeglib --enable-R-shlib --with-blas --with-lapack"
+ENV TZ=UTC
+ENV CRAN_MIRROR=$CRAN_MIRROR
+
+# Step 3 - Install R dependencies
+# Since we are using Ubuntu base image, we must first install the Debian dependencies that R requires before we can install it. 
+# We will use the apt-get command to install those dependencies and some command-line tools.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-utils\
+    gfortran \
+    git \
+    g++ \
+    libreadline-dev \
+    libx11-dev \
+    libxt-dev \
+    libpng-dev \
+    libjpeg-dev \
+    libcairo2-dev \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    libxml2-dev \
+    libudunits2-dev \
+    libgdal-dev \
+    libbz2-dev \
+    libzstd-dev \
+    liblzma-dev \
+    libpcre2-dev \
+    locales \
+    openjdk-8-jdk \
+    screen \
+    texinfo \
+    texlive \
+    texlive-fonts-extra \
+    vim \
+    wget \
+    xvfb \
+    tzdata \
+    sudo\
+    jq\
+    curl\
+    libgit2-dev \
+    libmagick++-dev \
+    make \
+    tmux \
+    # python3-launchpadlib \
+    # python3.10-dev \
+    # python3.10-venv \
+    # python3-pip \
+    lsof \
+    && rm -rf /var/lib/apt/lists/*
+
+# Step 4 - Install R
+RUN wget https://cran.rstudio.com/src/base/R-${R_VERSION_MAJOR}/R-${R_VERSION_MAJOR}.${R_VERSION_MINOR}.${R_VERSION_PATCH}.tar.gz && \
+    tar zxvf R-${R_VERSION_MAJOR}.${R_VERSION_MINOR}.${R_VERSION_PATCH}.tar.gz && \
+    rm R-${R_VERSION_MAJOR}.${R_VERSION_MINOR}.${R_VERSION_PATCH}.tar.gz
+
+WORKDIR /R-${R_VERSION_MAJOR}.${R_VERSION_MINOR}.${R_VERSION_PATCH}
+
+RUN ./configure ${CONFIGURE_OPTIONS} && \
+    make && \
+    make install
+
+RUN locale-gen en_US.UTF-8
+
+WORKDIR /root
+
+RUN mkdir settings
+
+# Step 5 - Install R packages
+COPY packages.json install_packages.R requirements.txt install_quarto.sh ./settings/
+RUN Rscript ./settings/install_packages.R
+
+# Step 6 - Install Quarto
+RUN bash ./settings/install_quarto.sh $QUARTO_VER
+COPY .Rprofile /root/
+
+# Step 7 - Set Python Environmentt
+RUN python3 -m venv /opt/$VENV_NAME  \
+    && export PATH=/opt/$VENV_NAME/bin:$PATH \
+    && echo "source /opt/$VENV_NAME/bin/activate" >> ~/.bashrc
+
+# Step 8 - Install radian (to run R on the command line)
+RUN pip3 install -r ./settings/requirements.txt

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -43,6 +43,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxt-dev \
     libpng-dev \
     libjpeg-dev \
+    libtiff-dev \
+    libfontconfig1-dev\
     libcairo2-dev \
     libcurl4-openssl-dev \
     libssl-dev \

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,4 +1,14 @@
-# Setting R Development Environment with VScode
+## Check if the container run correctly:
+
+In radian terminal run:
+`gitOption("bitmapType")`
+
+then if:
+- the answer is `"cairo"` perfect!
+- otherwise *Rebuild and Reopen the container* until the option `bitmapType` is `"cairo"`.
+- Alternatively open a new zsh terminal (inside the container) and launch `radian`. It should automatically pick "cairo" as graphic device.
+
+## Setting R Development Environment with VScode
 
 So far, we reviewed the foundation of Docker. We saw how to set and build an image with the Dockerfile and the build command, respectively, and then run it in a container with the run command. This section will focus on setting up an R development environment with VScode which includes:
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,220 @@
+# Setting R Development Environment with VScode
+
+So far, we reviewed the foundation of Docker. We saw how to set and build an image with the Dockerfile and the build command, respectively, and then run it in a container with the run command. This section will focus on setting up an R development environment with VScode which includes:
+
+- Set a Dockerfile with the R environment settings
+- Define the Dev Containers extension settings
+
+
+## General Requirements
+Before we start setting up our R development environment, let's define the scope:
+
+- R version 4.4.2
+- R core packages (e.g., tidyverse, plotly, shiny)
+- Quarto version 1.6.40
+- Support interactive R applications such as Shiny app, htmlwidget, etc.
+- Plot viewers
+- Tables viewer
+- Help viewer
+
+In addition, we will use `radian` to run R on the command line. **Radian** is an alternative R console with code completion and syntax highlight features.
+
+**NOTE:** Last but not least, we will build the image to enable us to update, modify, and add new components seamlessly.
+
+## Image Build Approach
+
+Here are the main options for setting image with R environment from simple to complex:
+
+- Pull a built-in and ready-to-use image from an external source such as the ones available on the Rocker project.
+- Pull a built-in image but add additional layers (e.g., required packages, etc.)
+- ***Build the image (almost) from scratch***
+
+Generally, I recommend using a robust and well-tested image as your baseline when applicable. This will save you or reduce the build time and potential debugging or handling dependencies issues. The Docker Hub is a good place to look for such images, and in the context of R, Rocker is the first place to check. 
+
+HERE we will go with the last option (***Build the image (almost) from scratch***) for learning purposes.
+
+It means that the starting point would be a clean and minimal Ubuntu image, which comes without the core R dependencies such C, C++, and Fortran compilers.<br/>
+In addition, we will have to set and define R's core configuration options, which, by default, in a regular OS such as Windows or macOS, you won't have to set or define.
+To ***make this process seamless and easy to update and modify*** if needed, we will use:
+
+- **Environment variables** to define the core properties of the R environment, such as R and Quarto version, default CRAN mirror, etc.
+- A **JSON file (packages.json)** with a list of required packages and their versions
+
+
+This will enable to update the environment just by updating the ***environment variables*** and the ***packages.json*** file.
+
+## DOCKERFILE - Installing required Dependencies
+# Step 3 - Install R dependencies
+```
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-utils\
+    gfortran \
+    git \
+    g++ \
+    libreadline-dev \
+    libx11-dev \
+    libxt-dev \
+    libpng-dev \
+    libjpeg-dev \
+    etc...
+```
+As we are setting the R environment almost from scratch, there is a long list of dependencies. This includes some Debian dependencies that are required to install R and some of the packages and command line tools. We use the RUN command to execute apt-get command to install those dependencies. One of the main challenges in this type of build is to identify what dependencies required them in the first place. While it is not in the scope of this tutorial, here are some tips:
+
+- **Build log** - when the build fails, the build log provides information about the error type or failure reason. By default, the docker build returns a concise output, which may not contain the error information. To get the full build log output, set the progress argument as plain (--progress=plain)
+- **System requirements** - when adding a new R package, check the package description to see if the SystemRequirements section is available. For example, *one of the R environment requirements is the **httpgd** package* that *enables running interactive R applications in VScode*, such as **Shiny** applications, or *HTML widgets*, such as **Plotly**. The package description provides the package system requirements (as can be seen in Figure 11 below) - **C++17**, **libpng**, **cairo**, **freetype2**, **fontconfig**, which must be installed before installing this package
+
+More details here: [Link](https://github.com/RamiKrispin/vscode-r?tab=readme-ov-file)
+
+## Installing R
+
+This section focuses on the 4th step - installing R and setting it. This includes the following sub-steps:
+
+- Install R from CRAN
+- Config and set R
+- Install packages
+- Install Quarto
+- Set the R profile
+We use the wget package (a command line application for downloading files from websites) to pull the R installation file as a tar file, extract it, and install it. Note that we use the arguments we set in step 2 to define the R version (default is 4.3.1):
+
+RUN wget https://cran.rstudio.com/src/base/R-${R_VERSION_MAJOR}/R-${R_VERSION_MAJOR}.${R_VERSION_MINOR}.${R_VERSION_PATCH}.tar.gz && \
+    tar zxvf R-${R_VERSION_MAJOR}.${R_VERSION_MINOR}.${R_VERSION_PATCH}.tar.gz && \
+    rm R-${R_VERSION_MAJOR}.${R_VERSION_MINOR}.${R_VERSION_PATCH}.tar.gz
+
+After we installed R inside the image, the next step is configuring it. <br/>
+We set the working directory and use the CONFIGURE_OPTIONS variable to define the R graphic and font settings:
+
+The WORKDIR command defines the folder we installed R as the default folder.<br/>
+`WORKDIR /R-${R_VERSION_MAJOR}.${R_VERSION_MINOR}.${R_VERSION_PATCH}`
+
+We use the make package to define the default settings and set the default fonts.<br/>
+`
+RUN ./configure ${CONFIGURE_OPTIONS} && \
+    make && \
+    make install
+`
+`RUN locale-gen en_US.UTF-8`
+
+
+## Installing R packages
+
+To install the required R packages, we will use the following helper scripts:
+
+- ***packages.json*** - A JSON file with a list of required packages and their versions
+- ***install_packages.R*** - A R script that parses the JSON file and installs the packages
+
+In the next step below, we set the root folder as the default, create a new folder named settings, and copy the above files to the settings folder:
+```
+WORKDIR /root
+
+RUN mkdir settings
+
+COPY packages.json install_packages.R requirements.txt install_quarto.sh ./settings/
+```
+
+Note: In addition to the packages.json and install_packages.R files, we also copied the requirements.txt and install_quarto.sh files which will be used to set the radian package and install Quarto
+
+Next, we execute the R script we copied to the settings folder:
+
+RUN Rscript ./settings/install_packages.R
+
+Note: The package installation process might take a few minutes. There are a few methods to speed up the process, such as installing the packages using the binary build or using renv, but it is outside the scope of this tutorial.
+
+## Setting the R profile
+
+The last step in this process is to copy the .Rprofile file to the root folder:
+
+`COPY .Rprofile /root/`
+
+The *.Rprofile* file allows us to set global configurations that R loads during the launch of a new session.
+
+## Installing radian
+
+We will use Radian to run R code on the terminal. <br/>
+Radian is a Python library that provides an interactive and colorful wrapper to the native R. It includes features such as:
+
+- Code completion
+- Syntax highlight
+
+To install radian, we will first *set up a virtual environment with venv*:
+```
+RUN python3 -m venv /opt/$VENV_NAME  \
+    && export PATH=/opt/$VENV_NAME/bin:$PATH \
+    && echo "source /opt/$VENV_NAME/bin/activate" >> ~/.bashrc
+```
+
+In the virtual environment, we can install radian. <br/>
+We will use the pip3 command with the requirements.txt file to install radian:
+```
+RUN pip3 install -r ./settings/requirements.txt
+```
+
+Generally, since in this specific case requirements.txt install only radian we could simply use:
+```
+RUN pip3 install radian
+```
+
+## Customize R environment (packges installed)
+
+The main goal of using arguments and environment variables with the Dockerfile is to enable modification and update the R environment. For example, as mentioned above, the R version is defined with the R_VERSION_MAJOR, R_VERSION_MINOR, and R_VERSION_PATCH arguments.
+
+The ***packages.json*** file defines the list of packages to install during the build time.
+
+For running R with VScode, we need the following two packages:
+
+- **languageserver** - An implementation of the Language Server Protocol for R, required for setting R in VScode
+- **httpgd** - Asynchronous HTTP server graphics device for R, used for viewing graphic applications in VScode
+
+
+In addition, to demonstrate some of the core use cases of R with VScode (e.g., graphic, interactivity, working with Shiny, etc.), we install the following packages:
+- **shiny**
+- **plotly**
+- **tidyverse**
+  
+The ***packages.json*** file enables o seamlessly set, update, and modify the installed packages and their versions. <br/>
+One thing to *note is that when adding new packages, you may need to install additional Debian dependencies (i.e., step 3)*. In some cases, those dependencies are specified on the package DESCRIPTION file. In other cases, when the build fails during the package installation, you will have to extract the missing dependencies from the error log.
+
+## Setting the Dev Continer (devcontainer.json file)
+
+The Dev Containers extension enables isolating a VScode session inside a containerized environment. <br/>
+By default, it mounts the local folder to the container and enables the mount of other local folders as well. <br/>
+This solves the container ephemeral issue and enables "enjoy" both worlds:
+  - running the code in an isolated environment
+  - keeping changes in the code locally (and not vanish in the ephemereal container)
+
+The devcontainer.json defines the environment settings and enables the customization of the image settings. That includes the following settings:
+
+- Image settings
+- Extensions settings
+- Environment variables
+- Mount additional folders
+
+## The settings.json File
+
+By default, VScode uses the default settings defined in the settings menu. However, there might be situations where you want to customize the settings on a project level. In such cases, you can make use of the settings.json file. By adding the settings.json file to your project folder under the .vscode folder, you can modify and override the default settings of VScode on a project level. This gives you complete control over the settings you want to use for your project.
+
+Below is the settings.json file we use in this repo to customize the functionality of the R for VScode extension:
+```
+{
+    "r.alwaysUseActiveTerminal": true,
+    "r.bracketedPaste": true,
+    "r.sessionWatcher": true,
+    "r.plot.useHttpgd": true,
+    "r.lsp.diagnostics": false
+}
+```
+You can notice from the structure of the JSON file that settings use the following structure:
+```
+{
+"Extension Name.Argument": Value
+}
+```
+
+where:
+
+- `r.alwaysUseActiveTerminal` - or always use active terminal, when set to true, it will send the R code by default to an open session (as opposed to opening a new terminal)
+- `r.bracketedPaste` - or bracketed paste, when set to true, will send an R code with brackets to the terminal. If set to false, any code with a bracket (e.g., for loop, if statement, etc.) will end up with an error.
+- `r.sessionWatcher` - or session watcher, when set to true, enables VScode to maintain the connection with an open R session in the terminal
+- `r.plot.useHttpgd` - or plot use httpgd, when set to true, will use the httpgd-based plot viewer instead of the base VScode R viewer
+- `r.lsp.diagnostics`: false - disable the default lintr diagnostic function via the language server package (you can set it to true if you find it useful)
+More information about the R for VScode extension settings available [here](https://github.com/REditorSupport/vscode-R/wiki/Extension-settings).
+

--- a/.devcontainer/build_docker.sh
+++ b/.devcontainer/build_docker.sh
@@ -3,19 +3,22 @@
 echo "Build the docker for Base R"
 
 docker buildx build . -f Dockerfile \
+   --no-cache=false \
    --progress=plain \
-   --tag r-shiny-vscode:v4.4.2
-   #    --platform linux/amd64 \
-   #    --no-cache=true \
-   #    --build-arg PROJECT_NAME="EIA Data Automation" \
-   #    --build-arg VENV_NAME="LEARN_GITHUB_ACTIONS" \
-   #    --build-arg DEBIAN_FRONTEND=noninteractive \
-   #    --build-arg QUARTO_VER=1.6.40 
+   --tag r-shiny-vscode:v4-4-2
+   # --build-arg PROJECT_NAME="R Shiny Dev" \
+   # --build-arg VENV_NAME="R_DEV_ENV" \
+   # --build-arg R_VERSION_MAJOR: "4" \
+   # --build-arg R_VERSION_MINOR: "4" \
+   # --build-arg R_VERSION_PATCH: "2" \
+   # --build-arg DEBIAN_FRONTEND=noninteractive \
+   # --build-arg CRAN_MIRROR=https://cran.rstudio.com/ \
+   # --build-arg QUARTO_VER="1.6.40" \
 
 if [[ $? = 0 ]] ; then
 echo "R Docker image correctly created"
 echo "Pushing docker..."
-docker push r-shiny-vscode:v4.4.2
+docker push r-shiny-vscode:v4-4-2
 else
 echo "Docker build failed"
 fi

--- a/.devcontainer/build_docker.sh
+++ b/.devcontainer/build_docker.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo "Build the docker for Base R"
+
+docker buildx build . -f Dockerfile \
+   --progress=plain \
+   --tag r-shiny-vscode:v4.4.2
+   #    --platform linux/amd64 \
+   #    --no-cache=true \
+   #    --build-arg PROJECT_NAME="EIA Data Automation" \
+   #    --build-arg VENV_NAME="LEARN_GITHUB_ACTIONS" \
+   #    --build-arg DEBIAN_FRONTEND=noninteractive \
+   #    --build-arg QUARTO_VER=1.6.40 
+
+if [[ $? = 0 ]] ; then
+echo "R Docker image correctly created"
+echo "Pushing docker..."
+docker push r-shiny-vscode:v4.4.2
+else
+echo "Docker build failed"
+fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,20 @@
 {
     "name": "R Dev Environment",
-    // "image": "r-shiny-vscode:v4.4.2", 
-    "build": {
-        "dockerfile": "Dockerfile",
-        "context": ".",
-        "args": {
-            "VENV_NAME": "SHINY_STOCK_ANALYZER",
-            "R_VERSION_MAJOR": "4",
-            "R_VERSION_MINOR": "4",
-            "R_VERSION_PATCH": "2",
-            "CRAN_MIRROR": "https://cran.rstudio.com/",
-            "QUARTO_VER": "1.6.40"
-        }
-    },
+    "image": "r-shiny-vscode:v4-4-2",
+    // "build": {
+    //     "dockerfile": "Dockerfile",
+    //     "context": ".",
+    //     "args": {
+    //         "VENV_NAME": "R_DEV_ENV",
+    //         "R_VERSION_MAJOR": "4",
+    //         "R_VERSION_MINOR": "4",
+    //         "R_VERSION_PATCH": "2",
+    //         "CRAN_MIRROR": "https://cran.rstudio.com/",
+    //         "QUARTO_VER": "1.6.40"
+    //     }
+    // },
     // Use Environment Variables
-    "remoteEnv": {
-        "VAR1":  "${localEnv:TERM_PROGRAM}", 
-        "VAR2": "${localEnv:TERM}"
-    },
+    "runArgs": ["--name", "R442-dev-env", "--rm"],
     // "runArgs": ["--env-file",".devcontainer/devcontainer.env"] alternative if instead of remoteEnv is used a devcontainer.env file  
     "customizations": {
         "vscode": {
@@ -40,9 +37,15 @@
             "settings": {
                 "files.associations": {
                     "*.Rmd": "rmd"
-                }
+                },
+                "python.defaultInterpreterPath": "/opt/R_DEV_SHINY/bin/python3",
+                "python.selectInterpreter": "/opt/R_DEV_SHINY/bin/python3",
+                "remote.autoForwardPorts": false
             }
-        } 
-    }, 
-    "postStartCommand": "radian"
- } 
+        }
+    },
+    "remoteEnv": {
+        "VAR1":  "${localEnv:TERM_PROGRAM}", 
+        "VAR2": "${localEnv:TERM}"
+    }
+} 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,48 @@
+{
+    "name": "R Dev Environment",
+    // "image": "r-shiny-vscode:v4.4.2", 
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".",
+        "args": {
+            "VENV_NAME": "SHINY_STOCK_ANALYZER",
+            "R_VERSION_MAJOR": "4",
+            "R_VERSION_MINOR": "4",
+            "R_VERSION_PATCH": "2",
+            "CRAN_MIRROR": "https://cran.rstudio.com/",
+            "QUARTO_VER": "1.6.40"
+        }
+    },
+    // Use Environment Variables
+    "remoteEnv": {
+        "VAR1":  "${localEnv:TERM_PROGRAM}", 
+        "VAR2": "${localEnv:TERM}"
+    },
+    // "runArgs": ["--env-file",".devcontainer/devcontainer.env"] alternative if instead of remoteEnv is used a devcontainer.env file  
+    "customizations": {
+        "vscode": {
+            "extensions": [
+            // R Extensions
+            "RDebugger.r-debugger",
+            "REditorSupport.r",
+            // Documentation Extensions
+            "quarto.quarto",
+            "purocean.drawio-preview",
+            "redhat.vscode-yaml",
+            "yzhang.markdown-all-in-one",
+            // Docker Supporting Extensions
+            "ms-azuretools.vscode-docker",
+            "ms-vscode-remote.remote-containers",
+            // Python Extensions
+            "ms-python.python",
+            "ms-toolsai.jupyter"
+        ],
+            "settings": {
+                "files.associations": {
+                    "*.Rmd": "rmd"
+                }
+            }
+        } 
+    }, 
+    "postStartCommand": "radian"
+ } 

--- a/.devcontainer/install_packages.R
+++ b/.devcontainer/install_packages.R
@@ -1,0 +1,77 @@
+# ---- Description
+# This file installs the required R packages on the Docker image during the build time. 
+# The list of packages and their versions is set on the packages.json file
+# ---- Dependencies
+# To parse the json jq must be installed on the docker image. 
+# See: https://stedolan.github.io/jq/
+# ---- Code starts here 
+# Set the working directory
+setwd("./settings/")
+# Required the remotes package
+install.packages("remotes", repos = "http://cran.rstudio.com/")
+#---- Load list of packages
+# Set the jq query
+jq_command <- 'jq -r ".packages[] |  [.package, .version] | @tsv" packages.json'
+# Debug mode
+# jq_command <- 'jq -r ".package_dev[] |  [.package, .version] | @tsv" packages.json'
+
+# Parse the json file with the list of package
+raw <- system(command = jq_command, intern = TRUE)
+
+package_list <- lapply(raw, function(i){
+  x <- unlist(strsplit(x = i, split = "\t"))
+  data.frame(package = x[1], version = x[2], stringsAsFactors = FALSE)
+})
+# Transform the list into a data.frame
+packages_df <- as.data.frame(t(matrix(unlist(package_list), nrow = 2)),
+                         stringsAsFactors = FALSE)
+names(packages_df) <- c("package", "version")
+packages_df$success <- FALSE
+
+# ---- Install the packages
+
+for(i in 1:nrow(packages_df)){
+  if(!packages_df$package[i] %in% rownames(installed.packages()) ||
+     (packages_df$package[i] %in% rownames(installed.packages()) &&
+      packageVersion(packages_df$package[i]) != packages_df$version[i])){
+    cat("\033[0;92m", paste("Installing", packages_df$package[i]), "\033[0m\n", sep = "")
+
+    remotes::install_version(package = packages_df$package[i],
+                             version = packages_df$version[i],
+                             dependencies = c("Depends", "Imports"),
+                             upgrade = FALSE,
+                             verbose = FALSE,
+                             quiet = FALSE,
+                             repos = "http://cran.rstudio.com/")
+  }
+
+  if(!packages_df$package[i] %in% rownames(installed.packages()) ||
+     (packages_df$package[i] %in% rownames(installed.packages()) &&
+      packageVersion(packages_df$package[i]) != packages_df$version[i])){
+    packages_df$success[i] <- FALSE
+  } else {
+    packages_df$success[i] <- TRUE
+  }
+}
+
+for(i in 1:nrow(packages_df)){
+    if(packages_df$success[i]){
+         cat("\033[0;92m",packages_df$package[i], "...OK", "\033[0m\n")
+    } else{
+         cat("\033[0;91m",packages_df$package[i], "...Fail", "\033[0m\n")
+    }
+}
+
+
+for(i in sort(c(packages_df$package))){
+  if(!i %in% rownames(installed.packages())){
+    f <- TRUE
+    cat("...Failed\n")
+  } else{
+    cat("...OK\n")
+  }
+}
+
+if(!any(packages_df$success)){
+  stop("One or more packages are missing...")
+}

--- a/.devcontainer/install_packages.R
+++ b/.devcontainer/install_packages.R
@@ -36,8 +36,8 @@ for(i in 1:nrow(packages_df)){
      (packages_df$package[i] %in% rownames(installed.packages()) &&
       packageVersion(packages_df$package[i]) != packages_df$version[i])){
     cat("\033[0;92m", paste("Installing", packages_df$package[i]), "\033[0m\n", sep = "")
-      # httpgd package not available in CRAN anymore. So that this is alternative
-      if(packages_df$package[i] %in% "httpgd") {
+      # httpgd and unigd packages not available in CRAN anymore. So that this is alternative
+      if(packages_df$package[i] %in% c("unigd", "httpgd")) {
         remotes::install_version(package = packages_df$package[i],
                              version = packages_df$version[i],
                              dependencies = c("Depends", "Imports"),

--- a/.devcontainer/install_quarto.sh
+++ b/.devcontainer/install_quarto.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+QUARTO_VERSION=$1
+
+echo "Installing Quarto version $QUARTO_VERSION"
+
+# Identify the CPU type (M1 vs Intel)
+if [[ $(uname -m) ==  "aarch64" ]] ; then
+  CPU="arm64"
+elif [[ $(uname -m) ==  "arm64" ]] ; then
+  CPU="arm64"
+else
+  CPU="amd64"
+fi
+
+
+TEMP_QUARTO="$(mktemp)" && \
+    wget  -O "$TEMP_QUARTO" https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-${QUARTO_VERSION}-linux-${CPU}.deb && \
+    sudo dpkg -i "$TEMP_QUARTO" && \
+    rm -f "$TEMP_QUARTO"

--- a/.devcontainer/packages.json
+++ b/.devcontainer/packages.json
@@ -1,0 +1,56 @@
+{
+    "packages": [
+        {
+            "package": "BH",
+            "version": "1.87.0-1",
+            "_comment": "Required by httpgd. Boost provides free peer-reviewed portable C++ source libraries. A large part of Boost is provided as C++ template code which is resolved entirely at compile-time without linking."
+        },
+        {
+            "package": "languageserver",
+            "version": "0.3.16",
+            "_comment": "Required by httpgd. An implementation of the Language Server Protocol for R. The Language Server protocol is used by an editor client to integrate features like auto completion."
+        },
+        {
+            "package": "httpgd",
+            "version": "2.0.2",
+            "_comment": "A graphics device for R that is accessible via network protocols. This package was created to make it easier to embed live R graphics in integrated development environments and other applications."
+        },
+        {
+            "package": "rmarkdown",
+            "version": "2.29",
+            "_comment": "Convert R Markdown documents into a variety of formats."
+        },
+        {
+            "package": "tidyverse",
+            "version": "2.0.0",
+            "_comment": "The 'tidyverse' is a set of packages that work in harmony because they share common data representations and 'API' design."
+        },
+        {
+            "package": "shiny",
+            "version": "1.10.0",
+            "_comment": "Makes it incredibly easy to build interactive web applications with R. Automatic 'reactive' binding between inputs and outputs and extensive prebuilt widgets"
+        },
+        {
+            "package": "plotly",
+            "version": "4.10.4",
+            "_comment": "Create interactive web graphics from 'ggplot2' graphs and/or a custom interface to the (MIT-licensed) JavaScript library 'plotly.js'."
+        },
+        {
+            "package": "usethis",
+            "version": "3.1.0",
+            "_comment": "Automate package and project setup tasks that are otherwise performed manually. This includes setting up unit testing, test coverage, continuous integration, Git, 'GitHub', licenses, 'Rcpp', 'RStudio' projects, and more."
+        }
+    ],
+    "package_dev": [
+        {
+            "package": "BH",
+            "version": "1.87.0-1",
+            "_comment": "Required by httpgd. Boost provides free peer-reviewed portable C++ source libraries. A large part of Boost is provided as C++ template code which is resolved entirely at compile-time without linking."
+        },
+        {
+            "package": "httpgd",
+            "version": "2.0.2",
+            "_comment": "A graphics device for R that is accessible via network protocols. This package was created to make it easier to embed live R graphics in integrated development environments and other applications."
+        }
+    ]
+}

--- a/.devcontainer/packages.json
+++ b/.devcontainer/packages.json
@@ -11,6 +11,16 @@
             "_comment": "Required by httpgd. An implementation of the Language Server Protocol for R. The Language Server protocol is used by an editor client to integrate features like auto completion."
         },
         {
+            "package": "AsioHeaders",
+            "version": "1.22.1-2",
+            "_comment": "Required by httpgd. 'Asio' is a cross-platform C++ library for network and low-level I/O programming that provides developers with a consistent asynchronous model using a modern C++ approach."
+        },
+        {
+            "package": "unigd",
+            "version": "0.1.2",
+            "_comment": "Required by httpgd. A universal graphical interface."
+        },
+        {
             "package": "httpgd",
             "version": "2.0.2",
             "_comment": "A graphics device for R that is accessible via network protocols. This package was created to make it easier to embed live R graphics in integrated development environments and other applications."

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,0 +1,3 @@
+# Radian is an alternative R console with code completion and syntax highlight features.
+# We use radian to run R on the command line.
+radian

--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,8 @@ vignettes/*.pdf
 # R Environment Variables
 .Renviron
 
+# Vs Code Dev Containers env variables
+devcontainer.env
+
 # Shiny cheatsheet
 Shiny cheatsheet.pdf

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "r.alwaysUseActiveTerminal": true,
+    "r.bracketedPaste": true,
+    "r.sessionWatcher": true,
+    "r.plot.useHttpgd": true,
+    "r.lsp.diagnostics": false
+}

--- a/test_container/app.R
+++ b/test_container/app.R
@@ -1,0 +1,59 @@
+library(shiny)
+
+# Define UI for app that draws a histogram ----
+ui <- fluidPage(
+
+  # App title ----
+  titlePanel("Hello Shiny!"),
+
+  # Sidebar layout with input and output definitions ----
+  sidebarLayout(
+
+    # Sidebar panel for inputs ----
+    sidebarPanel(
+
+      # Input: Slider for the number of bins ----
+      sliderInput(inputId = "bins",
+                  label = "Number of bins:",
+                  min = 1,
+                  max = 50,
+                  value = 30)
+
+    ),
+
+    # Main panel for displaying outputs ----
+    mainPanel(
+
+      # Output: Histogram ----
+      plotOutput(outputId = "distPlot")
+
+    )
+  )
+)
+
+# Define server logic required to draw a histogram ----
+server <- function(input, output) {
+
+  # Histogram of the Old Faithful Geyser Data ----
+  # with requested number of bins
+  # This expression that generates a histogram is wrapped in a call
+  # to renderPlot to indicate that:
+  #
+  # 1. It is "reactive" and therefore should be automatically
+  #    re-executed when inputs (input$bins) change
+  # 2. Its output type is a plot
+  output$distPlot <- renderPlot({
+
+    x    <- faithful$waiting
+    bins <- seq(min(x), max(x), length.out = input$bins + 1)
+
+    hist(x, breaks = bins, col = "#75AADB", border = "white",
+         xlab = "Waiting time to next eruption (in mins)",
+         main = "Histogram of waiting times")
+
+    })
+
+}
+
+# Create Shiny app ----
+shinyApp(ui = ui, server = server)

--- a/test_container/htmlwidgets.R
+++ b/test_container/htmlwidgets.R
@@ -1,0 +1,13 @@
+# Source: https://plotly.com/r/line-and-scatter/
+library(plotly)
+
+d <- diamonds[sample(nrow(diamonds), 1000), ]
+
+fig <- plot_ly(
+  d,
+  x = ~carat, y = ~price,
+  color = ~carat, size = ~carat,
+  type = "scatter", mode = "markers"
+)
+
+fig

--- a/test_container/plot.R
+++ b/test_container/plot.R
@@ -1,0 +1,33 @@
+library(ggplot2)
+
+data(diamonds)
+
+head(diamonds)
+
+View(diamonds)
+
+d <- diamonds[sample(nrow(diamonds), 2000), ]
+
+ggplot(data = d, aes(
+        x = carat,
+        y = price,
+        col = carat,
+        size = carat
+    )) +
+    geom_point()
+
+
+ggplot(data = d, aes(
+        x = carat,
+        y = price,
+        col = cut,
+        size = carat
+    )) +
+     geom_point()
+
+ggplot(data = d, aes(
+        x = carat,
+        y = price,
+        col = cut
+    )) +
+    geom_point()


### PR DESCRIPTION
- Added a Dev Container (VS-code Docker) with 
1. Ubuntu24.04 as OS
2. R (version 4.4.2)
3. Quarto 1.6.40
4. Classic R packages: `Shiny`, `tidyverse`, `plotly`
5. Python (Ubuntu default 3.12.3) with an virtual environment created (R_DEV_ENV) and necessary to run `radian`.
6. Installed `radian` inside the Python virtual env. R_DEV_ENV
7. Setup and .Rprofile that is picked at radian start (to make sure every graph/plot could be displayed in a VS Code editor tab.)
8. added Vs-code `settings.json` to regulate Vs-code behaviour when running `R`.
9. On top of existing folder `test_app` added folder `test_container` for testing Dev container basic functionality.
10. Added a `.devcontainer/README.md` file, with instructions on how a vs-code for R dev container should behave and be handled.